### PR TITLE
Add library.json meta-info file for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,21 @@
+{
+    "name": "STM8_headers",
+    "version": "0.0.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/gicking/STM8_headers.git"
+    },
+    "authors": {
+        "name": "Georg Icking-Konert",
+        "email": "icking@onlinehome.de",
+        "url": "https://github.com/gicking"
+    },
+    "license": "MIT",
+    "platforms": "ststm8",
+    "frameworks": "*",
+    "build": {
+        "flags": [
+            "-I include/"
+        ]
+    }
+}


### PR DESCRIPTION
Adds the [`library.json`](https://docs.platformio.org/en/latest/librarymanager/config.html) file. 

This allows PlatformIO to use this repository as a library, in e.g. a [`lib_deps`](https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-deps) expression, while adding the necessary build information.

An example project `platformio.ini` configuration can then be:

```ini
[env:nucleo_8s207k8]
platform = ststm8
board = nucleo_8s207k8
lib_deps = 
   https://github.com/gicking/STM8_headers.git
```

to use this library very easily in a bare-metal setting.

Also declares the version as 0.0.1 -- this repo doesn't containg verison info or git tags as far as I've seen.